### PR TITLE
Document Response::error and fix `log_errors` feature

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -158,9 +158,9 @@ impl<M: Machine> Handler<M>
             let ref mut scope = scope(time, token, context, channel, eloop);
             let (mach, void, timeout) =  decompose(token, fun(scope));
             void.map(|x| unreachable(x));
-            let m = mach.expect("You can't return Response::done() \
-                  from Machine::create() until new release of slab crate. \
-                  (requires insert_with_opt)");
+            let m = mach.expect("You can't return Response::done() or \
+                  Reponse::error() from Machine::create() until new release \
+                  of slab crate. (requires insert_with_opt)");
             let to = set_timeout_opt(timeout, scope);
             (to, m)
         });

--- a/src/response.rs
+++ b/src/response.rs
@@ -25,9 +25,19 @@ impl<M: Sized, N:Sized> Response<M, N> {
     pub fn done() -> Response<M, N> {
         Response::<M, N>(ResponseImpl::Done)
     }
+
+    /// Stop the state machine with an error.
+    ///
+    /// If `rotor` was compiled with the `log_errors` feature, the error will
+    /// be logged on the warning level.
+
+    // TODO add this documentation once mio has upgraded to slab 0.2.0
+    // Additionally, if this response is returned from `Machine::create`,
+    // the error is passed to `Machine::spawn_error`.
     pub fn error(e: Box<Error>) -> Response<M, N> {
         Response::<M, N>(ResponseImpl::Error(e))
     }
+
     pub fn deadline(self, time: Time) -> Response<M, N> {
         let imp = match self.0 {
             ResponseImpl::Normal(x) => ResponseImpl::Deadline(x, time),
@@ -179,7 +189,7 @@ pub fn decompose<M, N>(token: Token, res: Response<M, N>)
         ResponseImpl::Spawn(m, n) => (Ok(m), Some(n), None),
         ResponseImpl::Done => (Err(None), None, None),
         ResponseImpl::Error(e) => {
-            if cfg!(log_errors) {
+            if cfg!(feature = "log_errors") {
                 warn!("State machine {:?} exited with error: {}", token, e);
             }
             (Err(Some(e)), None, None)


### PR DESCRIPTION
Cargo features are available with `feature = "..."` in `cfg`'s ([Source](http://doc.crates.io/manifest.html#the-features-section)).
